### PR TITLE
Implement MultiAddr

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,7 @@ plugins {
 
 repositories {
     mavenCentral()
+    maven("https://jitpack.io")
 }
 
 dependencies {
@@ -21,6 +22,8 @@ dependencies {
     compile("com.google.guava:guava:27.1-jre")
     compile("org.bouncycastle:bcprov-jdk15on:1.61")
     compile("org.bouncycastle:bcpkix-jdk15on:1.61")
+    compile("com.github.multiformats:java-multiaddr:v1.3.1")
+
 
     testCompile("org.junit.jupiter:junit-jupiter-api:5.4.2")
     testCompile("org.junit.jupiter:junit-jupiter-params:5.4.2")

--- a/src/main/kotlin/io/libp2p/core/Host.kt
+++ b/src/main/kotlin/io/libp2p/core/Host.kt
@@ -6,7 +6,7 @@ import io.libp2p.core.security.SecureChannel
 /**
  * The Host is the libp2p entrypoint.
  */
-class Host private constructor (id: PeerId, secureChannels: Map<ProtocolMatcher, SecureChannel>) {
+class Host private constructor (var id: PeerId?, var secureChannels: Map<ProtocolMatcher, SecureChannel>) {
 
     fun peer(id: PeerId): Peer = TODO()
 
@@ -37,7 +37,7 @@ class Host private constructor (id: PeerId, secureChannels: Map<ProtocolMatcher,
         fun build(): Host {
             // TODO: validate parameters.
 
-            return Host(id!!, secureChannels)
+            return Host(id, secureChannels)
         }
     }
 }

--- a/src/main/kotlin/io/libp2p/core/multiformats/Multiaddr.kt
+++ b/src/main/kotlin/io/libp2p/core/multiformats/Multiaddr.kt
@@ -6,7 +6,7 @@ import io.libp2p.core.types.toByteBuf
 import io.netty.buffer.ByteBuf
 import io.netty.buffer.Unpooled
 
-class Multiaddr(val components: Array<Pair<Protocol, ByteArray>>) {
+class Multiaddr(val components: List<Pair<Protocol, ByteArray>>) {
 
     constructor(addr: String) : this(parseString(addr))
 
@@ -33,14 +33,14 @@ class Multiaddr(val components: Array<Pair<Protocol, ByteArray>>) {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
         other as Multiaddr
-        if (!components.contentEquals(other.components)) return false
+        if (!components.equals(other.components)) return false
         return true
     }
 
-    override fun hashCode(): Int =  components.contentHashCode()
+    override fun hashCode(): Int =  components.hashCode()
 
     companion object {
-        private fun parseString(addr_: String): Array<Pair<Protocol, ByteArray>> {
+        private fun parseString(addr_: String): List<Pair<Protocol, ByteArray>> {
             val ret: MutableList<Pair<Protocol, ByteArray>> = mutableListOf()
 
             try {
@@ -72,16 +72,16 @@ class Multiaddr(val components: Array<Pair<Protocol, ByteArray>>) {
             } catch (e: Exception) {
                 throw IllegalArgumentException("Malformed multiaddr: '$addr_", e)
             }
-            return ret.toTypedArray()
+            return ret
         }
 
-        private fun parseBytes(buf: ByteBuf): Array<Pair<Protocol, ByteArray>> {
+        private fun parseBytes(buf: ByteBuf): List<Pair<Protocol, ByteArray>> {
             val ret: MutableList<Pair<Protocol, ByteArray>> = mutableListOf()
             while (buf.isReadable) {
                 val protocol = Protocol.getOrThrow(buf.readUvarint().toInt())
                 ret.add(protocol to protocol.readAddressBytes(buf).toByteArray())
             }
-            return ret.toTypedArray()
+            return ret
         }
     }
 }

--- a/src/main/kotlin/io/libp2p/core/multiformats/Multiaddr.kt
+++ b/src/main/kotlin/io/libp2p/core/multiformats/Multiaddr.kt
@@ -4,6 +4,7 @@ import io.libp2p.core.types.readUvarint
 import io.libp2p.core.types.toByteArray
 import io.libp2p.core.types.toByteBuf
 import io.netty.buffer.ByteBuf
+import io.netty.buffer.Unpooled
 
 class Multiaddr(val components: Array<Pair<Protocol, ByteArray>>) {
 
@@ -12,10 +13,21 @@ class Multiaddr(val components: Array<Pair<Protocol, ByteArray>>) {
     constructor(bytes: ByteBuf) : this(parseBytes(bytes))
     constructor(bytes: ByteArray) : this(parseBytes(bytes.toByteBuf()))
 
-    fun getStringComponents(): List<Pair<Protocol, String>> =
-        components.map { p -> p.first to p.first.bytesToAddress(p.second.toByteBuf()) }
+    fun getStringComponents(): List<Pair<Protocol, String?>> =
+        components.map { p -> p.first to if (p.first.size == 0) null else p.first.bytesToAddress(p.second) }
 
-    override fun toString(): String = getStringComponents().joinToString { p -> "/" + p.first.typeName + "/" + p.second }
+    fun writeBytes(buf: ByteBuf) : ByteBuf {
+        for (component in components) {
+            buf.writeBytes(component.first.encoded)
+            buf.writeBytes(component.second)
+        }
+        return buf
+    }
+
+    fun getBytes() : ByteArray = writeBytes(Unpooled.buffer()).toByteArray()
+
+    override fun toString(): String = getStringComponents().joinToString(separator = "")
+            { p -> "/" + p.first.typeName + if (p.second != null) "/" + p.second else ""}
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -31,30 +43,34 @@ class Multiaddr(val components: Array<Pair<Protocol, ByteArray>>) {
         private fun parseString(addr_: String): Array<Pair<Protocol, ByteArray>> {
             val ret: MutableList<Pair<Protocol, ByteArray>> = mutableListOf()
 
-            var addr = addr_
-            while (addr.endsWith("/"))
-                addr = addr.substring(0, addr.length - 1)
-            val parts = addr.split("/")
-            if (parts[0].isNotEmpty()) throw IllegalStateException("MultiAddress must start with a /")
+            try {
+                var addr = addr_
+                while (addr.endsWith("/"))
+                    addr = addr.substring(0, addr.length - 1)
+                val parts = addr.split("/")
+                if (parts[0].isNotEmpty()) throw IllegalArgumentException("MultiAddress must start with a /")
 
-            var i = 1
-            while (i < parts.size) {
-                val part = parts[i++]
-                val p = Protocol.getOrThrow(part)
+                var i = 1
+                while (i < parts.size) {
+                    val part = parts[i++]
+                    val p = Protocol.getOrThrow(part)
 
-                val bytes = if (p.size == 0) ByteArray(0) else {
-                    val component = if (p.isPath())
-                        "/" + parts.subList(i, parts.size).reduce { a, b -> "$a/$b" }
-                    else parts[i++]
+                    val bytes = if (p.size == 0) ByteArray(0) else {
+                        val component = if (p.isPath())
+                            "/" + parts.subList(i, parts.size).reduce { a, b -> "$a/$b" }
+                        else parts[i++]
 
-                    if (component.isEmpty())
-                        throw IllegalStateException("Protocol requires address, but non provided!")
-                    p.addressToBytes(component)
+                        if (component.isEmpty())
+                            throw IllegalArgumentException("Protocol requires address, but non provided!")
+                        p.addressToBytes(component)
+                    }
+                    ret.add(p to bytes)
+
+                    if (p.isPath())
+                        break
                 }
-                ret.add(p to bytes)
-
-                if (p.isPath())
-                    break
+            } catch (e: Exception) {
+                throw IllegalArgumentException("Malformed multiaddr: '$addr_", e)
             }
             return ret.toTypedArray()
         }

--- a/src/main/kotlin/io/libp2p/core/multiformats/Multiaddr.kt
+++ b/src/main/kotlin/io/libp2p/core/multiformats/Multiaddr.kt
@@ -1,5 +1,71 @@
 package io.libp2p.core.multiformats
 
-class Multiaddr {
+import io.libp2p.core.types.readUvarint
+import io.libp2p.core.types.toByteArray
+import io.libp2p.core.types.toByteBuf
+import io.netty.buffer.ByteBuf
 
+class Multiaddr(val components: Array<Pair<Protocol, ByteArray>>) {
+
+    constructor(addr: String) : this(parseString(addr))
+
+    constructor(bytes: ByteBuf) : this(parseBytes(bytes))
+    constructor(bytes: ByteArray) : this(parseBytes(bytes.toByteBuf()))
+
+    fun getStringComponents(): List<Pair<Protocol, String>> =
+        components.map { p -> p.first to p.first.bytesToAddress(p.second.toByteBuf()) }
+
+    override fun toString(): String = getStringComponents().joinToString { p -> "/" + p.first.typeName + "/" + p.second }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        other as Multiaddr
+        if (!components.contentEquals(other.components)) return false
+        return true
+    }
+
+    override fun hashCode(): Int =  components.contentHashCode()
+
+    companion object {
+        private fun parseString(addr_: String): Array<Pair<Protocol, ByteArray>> {
+            val ret: MutableList<Pair<Protocol, ByteArray>> = mutableListOf()
+
+            var addr = addr_
+            while (addr.endsWith("/"))
+                addr = addr.substring(0, addr.length - 1)
+            val parts = addr.split("/")
+            if (parts[0].isNotEmpty()) throw IllegalStateException("MultiAddress must start with a /")
+
+            var i = 1
+            while (i < parts.size) {
+                val part = parts[i++]
+                val p = Protocol.getOrThrow(part)
+
+                val bytes = if (p.size == 0) ByteArray(0) else {
+                    val component = if (p.isPath())
+                        "/" + parts.subList(i, parts.size).reduce { a, b -> "$a/$b" }
+                    else parts[i++]
+
+                    if (component.isEmpty())
+                        throw IllegalStateException("Protocol requires address, but non provided!")
+                    p.addressToBytes(component)
+                }
+                ret.add(p to bytes)
+
+                if (p.isPath())
+                    break
+            }
+            return ret.toTypedArray()
+        }
+
+        private fun parseBytes(buf: ByteBuf): Array<Pair<Protocol, ByteArray>> {
+            val ret: MutableList<Pair<Protocol, ByteArray>> = mutableListOf()
+            while (buf.isReadable) {
+                val protocol = Protocol.getOrThrow(buf.readUvarint().toInt())
+                ret.add(protocol to protocol.readAddressBytes(buf).toByteArray())
+            }
+            return ret.toTypedArray()
+        }
+    }
 }

--- a/src/main/kotlin/io/libp2p/core/multiformats/Multiaddr.kt
+++ b/src/main/kotlin/io/libp2p/core/multiformats/Multiaddr.kt
@@ -6,7 +6,7 @@ import io.libp2p.core.types.toByteBuf
 import io.netty.buffer.ByteBuf
 import io.netty.buffer.Unpooled
 
-class Multiaddr(val components: List<Pair<Protocol, ByteArray>>) {
+data class Multiaddr(val components: List<Pair<Protocol, ByteArray>>) {
 
     constructor(addr: String) : this(parseString(addr))
 
@@ -28,16 +28,6 @@ class Multiaddr(val components: List<Pair<Protocol, ByteArray>>) {
 
     override fun toString(): String = getStringComponents().joinToString(separator = "")
             { p -> "/" + p.first.typeName + if (p.second != null) "/" + p.second else ""}
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-        other as Multiaddr
-        if (!components.equals(other.components)) return false
-        return true
-    }
-
-    override fun hashCode(): Int =  components.hashCode()
 
     companion object {
         private fun parseString(addr_: String): List<Pair<Protocol, ByteArray>> {

--- a/src/main/kotlin/io/libp2p/core/multiformats/Multihash.kt
+++ b/src/main/kotlin/io/libp2p/core/multiformats/Multihash.kt
@@ -86,7 +86,7 @@ class Multihash(val bytes: ByteBuf, val desc: Descriptor, val lengthBits: Int, v
             val code = code ?: REGISTRY[desc]?.code ?: throw InvalidMultihashException("Unrecognised multihash descriptor")
             with(Unpooled.buffer(lengthBytes + 10)) {
                 writeUvarint(code)
-                writeUvarint(lengthBytes.toLong())
+                writeUvarint(lengthBytes)
                 writeBytes(digest.slice(0, lengthBytes))
                 return Multihash(this, desc, lengthBits, digest)
             }

--- a/src/main/kotlin/io/libp2p/core/multiformats/Protocol.kt
+++ b/src/main/kotlin/io/libp2p/core/multiformats/Protocol.kt
@@ -1,0 +1,139 @@
+package io.libp2p.core.multiformats
+
+import io.ipfs.multiaddr.Base32
+import io.ipfs.multiaddr.Protocol.LENGTH_PREFIXED_VAR_SIZE
+import io.libp2p.core.types.readUvarint
+import io.libp2p.core.types.toByteArray
+import io.libp2p.core.types.writeUvarint
+import io.netty.buffer.ByteBuf
+import java.net.Inet4Address
+import java.net.Inet6Address
+import java.nio.charset.StandardCharsets
+import io.netty.buffer.Unpooled.buffer as byteBuf
+
+/**
+ * Partially translated from https://github.com/multiformats/java-multiaddr
+ */
+enum class Protocol(val code: Int, val size: Int, val typeName: String) {
+
+    IP4(4, 32, "ip4"),
+    TCP(6, 16, "tcp"),
+    UDP(17, 16, "udp"),
+    DCCP(33, 16, "dccp"),
+    IP6(41, 128, "ip6"),
+    DNS4(54, LENGTH_PREFIXED_VAR_SIZE, "dns4"),
+    DNS6(55, LENGTH_PREFIXED_VAR_SIZE, "dns6"),
+    DNSADDR(56, LENGTH_PREFIXED_VAR_SIZE, "dnsaddr"),
+    SCTP(132, 16, "sctp"),
+    UTP(301, 0, "utp"),
+    UDT(302, 0, "udt"),
+    UNIX(400, LENGTH_PREFIXED_VAR_SIZE, "unix") {
+        override fun isPath() = true
+    },
+    IPFS(421, LENGTH_PREFIXED_VAR_SIZE, "ipfs"),
+    HTTPS(443, 0, "https"),
+    ONION(444, 80, "onion"),
+    QUIC(460, 0, "quic"),
+    WS(477, 0, "ws"),
+    P2PCIRCUIT(290, 0, "p2p-circuit"),
+    HTTP(480, 0, "http");
+
+    private val LENGTH_PREFIXED_VAR_SIZE = -1
+
+    val encoded: ByteArray = encode(code)
+
+    private fun encode(type: Int): ByteArray =
+        byteBuf(4).writeUvarint(type.toLong()).toByteArray()
+
+    open fun isPath() = false
+
+    fun addressToBytes(addr: String): ByteArray =
+        when (this) {
+            IP4 -> Inet4Address.getByName(addr).address
+            IP6 -> Inet6Address.getByName(addr).address
+            TCP, UDP, DCCP, SCTP -> {
+                val x = Integer.parseInt(addr)
+                if (x > 65535) throw IllegalArgumentException("Failed to parse $this address $x > 65535")
+                byteBuf(2).writeShort(x).toByteArray()
+            }
+            ONION -> {
+                val split = addr.split(":")
+                if (split.size != 2) throw IllegalArgumentException("Onion address needs a port: $addr")
+                // onion address without the ".onion" substring
+                if (split[0].length != 16) throw IllegalArgumentException("failed to parse $this addr: $addr not a Tor onion address.")
+
+                val onionHostBytes = Base32.decode(split[0].toUpperCase())
+                val port = split[1].toInt()
+                if (port > 65535) throw IllegalArgumentException("Port is > 65535: $port")
+                if (port < 1) throw IllegalArgumentException("Port is < 1: $port")
+
+                byteBuf(18)
+                    .writeBytes(onionHostBytes)
+                    .writeShort(port)
+                    .toByteArray();
+            }
+            UNIX -> {
+                val addr1 = if (addr.startsWith("/")) addr.substring(1) else addr
+                val path = addr1.toByteArray(StandardCharsets.UTF_8)
+                byteBuf(path.size + 8)
+                    .writeUvarint(path.size.toLong())
+                    .writeBytes(path)
+                    .toByteArray()
+            }
+            DNS4, DNS6, DNSADDR -> {
+                val hashBytes = addr.toByteArray(StandardCharsets.UTF_8)
+                byteBuf(hashBytes.size + 8)
+                    .writeUvarint(hashBytes.size.toLong())
+                    .writeBytes(hashBytes)
+                    .toByteArray()
+            }
+            else -> throw IllegalArgumentException("Unknown multiaddr type: $this")
+        }
+
+    fun readAddressBytes(buf: ByteBuf) = buf.readBytes(sizeForAddress(buf))
+
+    fun bytesToAddress(buf: ByteBuf): String {
+        val addressBytes = readAddressBytes(buf);
+        return when (this) {
+            IP4 -> {
+                Inet4Address.getByAddress(addressBytes.toByteArray())
+                    .toString().substring(1)
+            }
+            IP6 -> {
+                Inet6Address.getByAddress(addressBytes.toByteArray())
+                    .toString().substring(1)
+            }
+            TCP, UDP, DCCP, SCTP -> addressBytes.readShort().toString()
+            ONION -> {
+                val host = addressBytes.readBytes(10).toByteArray()
+                val port = addressBytes.readShort()
+                Base32.encode(host) + ":" + port
+            }
+            UNIX, DNS4, DNS6, DNSADDR -> {
+                val pathBytes = addressBytes.toByteArray()
+                String(pathBytes, StandardCharsets.UTF_8)
+            }
+            else -> throw IllegalStateException("Unimplemented protocol type: $this")
+        }
+    }
+
+    private fun sizeForAddress(buf: ByteBuf) =
+        if (size != LENGTH_PREFIXED_VAR_SIZE) size / 8 else buf.readUvarint().toInt()
+
+    companion object {
+        private val byCode = values().associate { p -> p.code to p }
+        private val byName = values().associate { p -> p.typeName to p }
+
+        @JvmStatic
+        fun get(code: Int) = byCode[code]
+
+        @JvmStatic
+        fun get(name: String) = byName[name]
+
+        @JvmStatic
+        fun getOrThrow(code: Int) = get(code) ?: throw IllegalArgumentException("Unknown protocol code: $code")
+
+        @JvmStatic
+        fun getOrThrow(name: String) = get(name) ?: throw IllegalArgumentException("Unknown protocol name: '$name'")
+    }
+}

--- a/src/main/kotlin/io/libp2p/core/multiformats/Protocol.kt
+++ b/src/main/kotlin/io/libp2p/core/multiformats/Protocol.kt
@@ -1,7 +1,6 @@
 package io.libp2p.core.multiformats
 
 import io.ipfs.multiaddr.Base32
-import io.ipfs.multiaddr.Protocol.LENGTH_PREFIXED_VAR_SIZE
 import io.libp2p.core.types.readUvarint
 import io.libp2p.core.types.toByteArray
 import io.libp2p.core.types.toByteBuf
@@ -22,24 +21,22 @@ enum class Protocol(val code: Int, val size: Int, val typeName: String) {
     UDP(17, 16, "udp"),
     DCCP(33, 16, "dccp"),
     IP6(41, 128, "ip6"),
-    DNS4(54, LENGTH_PREFIXED_VAR_SIZE, "dns4"),
-    DNS6(55, LENGTH_PREFIXED_VAR_SIZE, "dns6"),
-    DNSADDR(56, LENGTH_PREFIXED_VAR_SIZE, "dnsaddr"),
+    DNS4(54, -1, "dns4"),
+    DNS6(55, -1, "dns6"),
+    DNSADDR(56, -1, "dnsaddr"),
     SCTP(132, 16, "sctp"),
     UTP(301, 0, "utp"),
     UDT(302, 0, "udt"),
-    UNIX(400, LENGTH_PREFIXED_VAR_SIZE, "unix") {
+    UNIX(400, -1, "unix") {
         override fun isPath() = true
     },
-    IPFS(421, LENGTH_PREFIXED_VAR_SIZE, "ipfs"),
+    IPFS(421, -1, "ipfs"),
     HTTPS(443, 0, "https"),
     ONION(444, 96, "onion"),
     QUIC(460, 0, "quic"),
     WS(477, 0, "ws"),
     P2PCIRCUIT(290, 0, "p2p-circuit"),
     HTTP(480, 0, "http");
-
-    private val LENGTH_PREFIXED_VAR_SIZE = -1
 
     val encoded: ByteArray = encode(code)
 
@@ -77,7 +74,7 @@ enum class Protocol(val code: Int, val size: Int, val typeName: String) {
                 byteBuf(18)
                     .writeBytes(onionHostBytes)
                     .writeShort(port)
-                    .toByteArray();
+                    .toByteArray()
             }
             UNIX -> {
                 val addr1 = if (addr.startsWith("/")) addr.substring(1) else addr
@@ -124,7 +121,7 @@ enum class Protocol(val code: Int, val size: Int, val typeName: String) {
     }
 
     private fun sizeForAddress(buf: ByteBuf) =
-        if (size != LENGTH_PREFIXED_VAR_SIZE) size / 8 else buf.readUvarint().toInt()
+        if (size >= 0) size / 8 else buf.readUvarint().toInt()
 
     companion object {
         private val byCode = values().associate { p -> p.code to p }

--- a/src/main/kotlin/io/libp2p/core/multiformats/Protocol.kt
+++ b/src/main/kotlin/io/libp2p/core/multiformats/Protocol.kt
@@ -20,7 +20,7 @@ enum class Protocol(val code: Int, val size: Int, val typeName: String) {
 
     IP4(4, 32, "ip4"),
     TCP(6, 16, "tcp"),
-    UDP(17, 16, "udp"),
+    UDP(273, 16, "udp"),
     DCCP(33, 16, "dccp"),
     IP6(41, 128, "ip6"),
     IP6ZONE(42, -1, "ip6zone"),

--- a/src/main/kotlin/io/libp2p/core/multiformats/Protocol.kt
+++ b/src/main/kotlin/io/libp2p/core/multiformats/Protocol.kt
@@ -13,6 +13,8 @@ import java.nio.charset.StandardCharsets
 import io.netty.buffer.Unpooled.buffer as byteBuf
 
 
+private const val LENGTH_PREFIXED_VAR_SIZE = -1
+
 /**
  * Partially translated from https://github.com/multiformats/java-multiaddr
  */
@@ -23,18 +25,18 @@ enum class Protocol(val code: Int, val size: Int, val typeName: String) {
     UDP(273, 16, "udp"),
     DCCP(33, 16, "dccp"),
     IP6(41, 128, "ip6"),
-    IP6ZONE(42, -1, "ip6zone"),
-    DNS4(54, -1, "dns4"),
-    DNS6(55, -1, "dns6"),
-    DNSADDR(56, -1, "dnsaddr"),
+    IP6ZONE(42, LENGTH_PREFIXED_VAR_SIZE, "ip6zone"),
+    DNS4(54, LENGTH_PREFIXED_VAR_SIZE, "dns4"),
+    DNS6(55, LENGTH_PREFIXED_VAR_SIZE, "dns6"),
+    DNSADDR(56, LENGTH_PREFIXED_VAR_SIZE, "dnsaddr"),
     SCTP(132, 16, "sctp"),
     UTP(301, 0, "utp"),
     UDT(302, 0, "udt"),
-    UNIX(400, -1, "unix") {
+    UNIX(400, LENGTH_PREFIXED_VAR_SIZE, "unix") {
         override fun isPath() = true
     },
-    IPFS(421, -1, "ipfs"),
-    P2P(421, -1, "p2p"),
+    IPFS(421, LENGTH_PREFIXED_VAR_SIZE, "ipfs"),
+    P2P(421, LENGTH_PREFIXED_VAR_SIZE, "p2p"),
     HTTPS(443, 0, "https"),
     ONION(444, 96, "onion"),
     QUIC(460, 0, "quic"),
@@ -134,7 +136,7 @@ enum class Protocol(val code: Int, val size: Int, val typeName: String) {
     }
 
     private fun sizeForAddress(buf: ByteBuf) =
-        if (size >= 0) size / 8 else buf.readUvarint().toInt()
+        if (size != LENGTH_PREFIXED_VAR_SIZE) size / 8 else buf.readUvarint().toInt()
 
     companion object {
         private val byCode = values().associate { p -> p.code to p }

--- a/src/main/kotlin/io/libp2p/core/types/ByteArrayExtensions.kt
+++ b/src/main/kotlin/io/libp2p/core/types/ByteArrayExtensions.kt
@@ -1,0 +1,6 @@
+package io.libp2p.core.types
+
+fun ByteArray.toHex() = this.joinToString(separator = "")
+    { it.toInt().and(0xff).toString(16).padStart(2, '0') }
+fun String.fromHex() = ByteArray(this.length / 2)
+    { this.substring(it * 2, it * 2 + 2).toInt(16).toByte() }

--- a/src/main/kotlin/io/libp2p/core/types/Uvarint.kt
+++ b/src/main/kotlin/io/libp2p/core/types/Uvarint.kt
@@ -2,6 +2,8 @@ package io.libp2p.core.types
 
 import io.netty.buffer.ByteBuf
 
+fun ByteBuf.writeUvarint(value: Int): ByteBuf = writeUvarint(value.toLong())
+
 fun ByteBuf.writeUvarint(value: Long): ByteBuf {
     var v = value
     while (v >= 0x80) {

--- a/src/main/kotlin/io/libp2p/core/types/Uvarint.kt
+++ b/src/main/kotlin/io/libp2p/core/types/Uvarint.kt
@@ -19,9 +19,9 @@ fun ByteBuf.readUvarint(): Long {
     var s = 0
 
     for (i in 0..9) {
-        val b = this.readByte().toUByte()
-        if (b < 0x80u) {
-            if (i == 9 && b > 1u) {
+        val b = this.readUnsignedByte()
+        if (b < 0x80) {
+            if (i == 9 && b > 1) {
                 throw IllegalStateException("Overflow reading uvarint")
             }
             return x or (b.toLong() shl s)

--- a/src/main/kotlin/io/libp2p/core/types/Uvarint.kt
+++ b/src/main/kotlin/io/libp2p/core/types/Uvarint.kt
@@ -17,9 +17,9 @@ fun ByteBuf.readUvarint(): Long {
     var s = 0
 
     for (i in 0..9) {
-        val b = this.readByte()
-        if (b < 0x80) {
-            if (i == 9 && b > 1) {
+        val b = this.readByte().toUByte()
+        if (b < 0x80u) {
+            if (i == 9 && b > 1u) {
                 throw IllegalStateException("Overflow reading uvarint")
             }
             return x or (b.toLong() shl s)

--- a/src/main/kotlin/io/libp2p/core/types/Uvarint.kt
+++ b/src/main/kotlin/io/libp2p/core/types/Uvarint.kt
@@ -2,13 +2,14 @@ package io.libp2p.core.types
 
 import io.netty.buffer.ByteBuf
 
-fun ByteBuf.writeUvarint(value: Long) {
+fun ByteBuf.writeUvarint(value: Long): ByteBuf {
     var v = value
     while (v >= 0x80) {
         this.writeByte((v or 0x80).toInt())
         v = v shr 7
     }
     this.writeByte(v.toInt())
+    return this
 }
 
 fun ByteBuf.readUvarint(): Long {

--- a/src/test/kotlin/io/libp2p/core/HostTest.kt
+++ b/src/test/kotlin/io/libp2p/core/HostTest.kt
@@ -11,7 +11,6 @@ class HostTest {
     fun testHost() {
         // Let's create a host! This is a nice fluent builder, kindly sponsored by Kotlin.
         val host = Host.create {
-
             secureChannels {
                 this[ProtocolMatcher(Mode.STRICT, name = "test")] = SecIoSecureChannel()
             }

--- a/src/test/kotlin/io/libp2p/core/HostTest.kt
+++ b/src/test/kotlin/io/libp2p/core/HostTest.kt
@@ -11,6 +11,7 @@ class HostTest {
     fun testHost() {
         // Let's create a host! This is a nice fluent builder, kindly sponsored by Kotlin.
         val host = Host.create {
+
             secureChannels {
                 this[ProtocolMatcher(Mode.STRICT, name = "test")] = SecIoSecureChannel()
             }

--- a/src/test/kotlin/io/libp2p/core/multiformats/MultiaddrTest.kt
+++ b/src/test/kotlin/io/libp2p/core/multiformats/MultiaddrTest.kt
@@ -1,0 +1,123 @@
+package io.libp2p.core.multiformats
+
+import com.google.common.io.BaseEncoding
+import io.libp2p.core.types.toByteBuf
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+class MultiaddrTest {
+
+    companion object {
+        @JvmStatic
+        fun params() = listOf(
+            Arguments.of(Multihash.Descriptor(Multihash.Digest.Identity), -1, "foo", "0003666f6f"),
+            Arguments.of(Multihash.Descriptor(Multihash.Digest.Identity), 24, "foo", "0003666f6f"),
+            Arguments.of(
+                Multihash.Descriptor(Multihash.Digest.Identity),
+                -1,
+                "foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoo",
+                "0030666f6f666f6f666f6f666f6f666f6f666f6f666f6f666f6f666f6f666f6f666f6f666f6f666f6f666f6f666f6f666f6f"
+            ),
+            Arguments.of(
+                Multihash.Descriptor(Multihash.Digest.SHA1, 160),
+                -1,
+                "foo",
+                "11140beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33"
+            ),
+            Arguments.of(Multihash.Descriptor(Multihash.Digest.SHA1, 160), 80, "foo", "110a0beec7b5ea3f0fdbc95d"),
+            Arguments.of(
+                Multihash.Descriptor(Multihash.Digest.SHA2, 256),
+                -1,
+                "foo",
+                "12202c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
+            ),
+            Arguments.of(
+                Multihash.Descriptor(Multihash.Digest.SHA2, 256),
+                128,
+                "foo",
+                "12102c26b46b68ffc68ff99b453c1d304134"
+            ),
+            Arguments.of(
+                Multihash.Descriptor(Multihash.Digest.SHA2, 512),
+                -1,
+                "foo",
+                "1340f7fbba6e0636f890e56fbbf3283e524c6fa3204ae298382d624741d0dc6638326e282c41be5e4254d8820772c5518a2c5a8c0c7f7eda19594a7eb539453e1ed7"
+            ),
+            Arguments.of(
+                Multihash.Descriptor(Multihash.Digest.SHA2, 512),
+                256,
+                "foo",
+                "1320f7fbba6e0636f890e56fbbf3283e524c6fa3204ae298382d624741d0dc663832"
+            ),
+            Arguments.of(
+                Multihash.Descriptor(Multihash.Digest.SHA3, 512),
+                256,
+                "foo",
+                "14204bca2b137edc580fe50a88983ef860ebaca36c857b1f492839d6d7392452a63c"
+            ),
+            Arguments.of(
+                Multihash.Descriptor(Multihash.Digest.SHA3, 512),
+                128,
+                "foo",
+                "14104bca2b137edc580fe50a88983ef860eb"
+            ),
+            Arguments.of(
+                Multihash.Descriptor(Multihash.Digest.SHA3, 512),
+                -1,
+                "foo",
+                "14404bca2b137edc580fe50a88983ef860ebaca36c857b1f492839d6d7392452a63c82cbebc68e3b70a2a1480b4bb5d437a7cba6ecf9d89f9ff3ccd14cd6146ea7e7"
+            ),
+            Arguments.of(
+                Multihash.Descriptor(Multihash.Digest.SHA3, 224),
+                -1,
+                "beep boop",
+                "171c0da73a89549018df311c0a63250e008f7be357f93ba4e582aaea32b8"
+            ),
+            Arguments.of(
+                Multihash.Descriptor(Multihash.Digest.SHA3, 224),
+                128,
+                "beep boop",
+                "17100da73a89549018df311c0a63250e008f"
+            ),
+            Arguments.of(
+                Multihash.Descriptor(Multihash.Digest.SHA3, 256),
+                -1,
+                "beep boop",
+                "1620828705da60284b39de02e3599d1f39e6c1df001f5dbf63c9ec2d2c91a95a427f"
+            ),
+            Arguments.of(
+                Multihash.Descriptor(Multihash.Digest.SHA3, 256),
+                128,
+                "beep boop",
+                "1610828705da60284b39de02e3599d1f39e6"
+            ),
+            Arguments.of(
+                Multihash.Descriptor(Multihash.Digest.SHA3, 384),
+                -1,
+                "beep boop",
+                "153075a9cff1bcfbe8a7025aa225dd558fb002769d4bf3b67d2aaf180459172208bea989804aefccf060b583e629e5f41e8d"
+            ),
+            Arguments.of(
+                Multihash.Descriptor(Multihash.Digest.SHA3, 384),
+                128,
+                "beep boop",
+                "151075a9cff1bcfbe8a7025aa225dd558fb0"
+            )
+        )
+    }
+
+    @ParameterizedTest
+    @MethodSource("params")
+    fun `Multihash digest and of`(desc: Multihash.Descriptor, length: Int, content: String, expected: String) {
+        val hex = BaseEncoding.base16()
+        val mh = Multihash.digest(desc, content.toByteArray().toByteBuf(), if (length == -1) null else length).bytes
+        val expected = hex.decode(expected.toUpperCase()).toByteBuf()
+        assertEquals(expected, mh)
+        with(Multihash.of(mh)) {
+            assertEquals(desc, this.desc)
+            if (length != -1) assertEquals(length, this.lengthBits)
+        }
+    }
+}

--- a/src/test/kotlin/io/libp2p/core/multiformats/MultiaddrTest.kt
+++ b/src/test/kotlin/io/libp2p/core/multiformats/MultiaddrTest.kt
@@ -1,123 +1,110 @@
 package io.libp2p.core.multiformats
 
-import com.google.common.io.BaseEncoding
-import io.libp2p.core.types.toByteBuf
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 
 class MultiaddrTest {
 
     companion object {
         @JvmStatic
-        fun params() = listOf(
-            Arguments.of(Multihash.Descriptor(Multihash.Digest.Identity), -1, "foo", "0003666f6f"),
-            Arguments.of(Multihash.Descriptor(Multihash.Digest.Identity), 24, "foo", "0003666f6f"),
-            Arguments.of(
-                Multihash.Descriptor(Multihash.Digest.Identity),
-                -1,
-                "foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoo",
-                "0030666f6f666f6f666f6f666f6f666f6f666f6f666f6f666f6f666f6f666f6f666f6f666f6f666f6f666f6f666f6f666f6f"
-            ),
-            Arguments.of(
-                Multihash.Descriptor(Multihash.Digest.SHA1, 160),
-                -1,
-                "foo",
-                "11140beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33"
-            ),
-            Arguments.of(Multihash.Descriptor(Multihash.Digest.SHA1, 160), 80, "foo", "110a0beec7b5ea3f0fdbc95d"),
-            Arguments.of(
-                Multihash.Descriptor(Multihash.Digest.SHA2, 256),
-                -1,
-                "foo",
-                "12202c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
-            ),
-            Arguments.of(
-                Multihash.Descriptor(Multihash.Digest.SHA2, 256),
-                128,
-                "foo",
-                "12102c26b46b68ffc68ff99b453c1d304134"
-            ),
-            Arguments.of(
-                Multihash.Descriptor(Multihash.Digest.SHA2, 512),
-                -1,
-                "foo",
-                "1340f7fbba6e0636f890e56fbbf3283e524c6fa3204ae298382d624741d0dc6638326e282c41be5e4254d8820772c5518a2c5a8c0c7f7eda19594a7eb539453e1ed7"
-            ),
-            Arguments.of(
-                Multihash.Descriptor(Multihash.Digest.SHA2, 512),
-                256,
-                "foo",
-                "1320f7fbba6e0636f890e56fbbf3283e524c6fa3204ae298382d624741d0dc663832"
-            ),
-            Arguments.of(
-                Multihash.Descriptor(Multihash.Digest.SHA3, 512),
-                256,
-                "foo",
-                "14204bca2b137edc580fe50a88983ef860ebaca36c857b1f492839d6d7392452a63c"
-            ),
-            Arguments.of(
-                Multihash.Descriptor(Multihash.Digest.SHA3, 512),
-                128,
-                "foo",
-                "14104bca2b137edc580fe50a88983ef860eb"
-            ),
-            Arguments.of(
-                Multihash.Descriptor(Multihash.Digest.SHA3, 512),
-                -1,
-                "foo",
-                "14404bca2b137edc580fe50a88983ef860ebaca36c857b1f492839d6d7392452a63c82cbebc68e3b70a2a1480b4bb5d437a7cba6ecf9d89f9ff3ccd14cd6146ea7e7"
-            ),
-            Arguments.of(
-                Multihash.Descriptor(Multihash.Digest.SHA3, 224),
-                -1,
-                "beep boop",
-                "171c0da73a89549018df311c0a63250e008f7be357f93ba4e582aaea32b8"
-            ),
-            Arguments.of(
-                Multihash.Descriptor(Multihash.Digest.SHA3, 224),
-                128,
-                "beep boop",
-                "17100da73a89549018df311c0a63250e008f"
-            ),
-            Arguments.of(
-                Multihash.Descriptor(Multihash.Digest.SHA3, 256),
-                -1,
-                "beep boop",
-                "1620828705da60284b39de02e3599d1f39e6c1df001f5dbf63c9ec2d2c91a95a427f"
-            ),
-            Arguments.of(
-                Multihash.Descriptor(Multihash.Digest.SHA3, 256),
-                128,
-                "beep boop",
-                "1610828705da60284b39de02e3599d1f39e6"
-            ),
-            Arguments.of(
-                Multihash.Descriptor(Multihash.Digest.SHA3, 384),
-                -1,
-                "beep boop",
-                "153075a9cff1bcfbe8a7025aa225dd558fb002769d4bf3b67d2aaf180459172208bea989804aefccf060b583e629e5f41e8d"
-            ),
-            Arguments.of(
-                Multihash.Descriptor(Multihash.Digest.SHA3, 384),
-                128,
-                "beep boop",
-                "151075a9cff1bcfbe8a7025aa225dd558fb0"
-            )
+        fun paramsInvalid() = listOf(
+            "/ip4",
+            "/ip4/::1",
+            "/ip4/fdpsofodsajfdoisa",
+            "/ip6",
+            "/ip6zone",
+            "/ip6zone/",
+            "/ip6zone//ip6/fe80::1",
+            "/udp",
+            "/tcp",
+            "/sctp",
+            "/udp/65536",
+            "/tcp/65536",
+            "/quic/65536",
+            "/onion/9imaq4ygg2iegci7:80",
+            "/onion/aaimaq4ygg2iegci7:80",
+            "/onion/timaq4ygg2iegci7:0",
+            "/onion/timaq4ygg2iegci7:-1",
+            "/onion/timaq4ygg2iegci7",
+            "/onion/timaq4ygg2iegci@:666",
+            "/udp/1234/sctp",
+            "/udp/1234/udt/1234",
+            "/udp/1234/utp/1234",
+            "/ip4/127.0.0.1/udp/jfodsajfidosajfoidsa",
+            "/ip4/127.0.0.1/udp",
+            "/ip4/127.0.0.1/tcp/jfodsajfidosajfoidsa",
+            "/ip4/127.0.0.1/tcp",
+            "/ip4/127.0.0.1/quic/1234",
+            "/ip4/127.0.0.1/ipfs",
+            "/ip4/127.0.0.1/ipfs/tcp",
+            "/ip4/127.0.0.1/p2p",
+            "/ip4/127.0.0.1/p2p/tcp",
+            "/unix",
+            "/ip4/1.2.3.4/tcp/80/unix"
+        )
+
+        @JvmStatic
+        fun paramsValid() = listOf(
+            "/ip4/1.2.3.4",
+            "/ip4/0.0.0.0",
+            "/ip6/0:0:0:0:0:0:0:1",
+            "/ip6/2601:9:4f81:9700:803e:ca65:66e8:c21",
+            "/ip6/2601:9:4f81:9700:803e:ca65:66e8:c21/udp/1234/quic",
+//            "/ip6zone/x/ip6/fe80::1",
+//            "/ip6zone/x%y/ip6/fe80::1",
+//            "/ip6zone/x%y/ip6/::",
+//            "/ip6zone/x/ip6/fe80::1/udp/1234/quic",
+            "/onion/timaq4ygg2iegci7:1234",
+            "/onion/timaq4ygg2iegci7:80/http",
+            "/udp/0",
+            "/tcp/0",
+            "/sctp/0",
+            "/udp/1234",
+            "/tcp/1234",
+            "/sctp/1234",
+            "/udp/65535",
+            "/tcp/65535",
+//            "/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
+//            "/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
+            "/udp/1234/sctp/1234",
+            "/udp/1234/udt",
+            "/udp/1234/utp",
+            "/tcp/1234/http",
+            "/tcp/1234/https",
+//            "/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234",
+//            "/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234",
+            "/ip4/127.0.0.1/udp/1234",
+            "/ip4/127.0.0.1/udp/0",
+            "/ip4/127.0.0.1/tcp/1234",
+            "/ip4/127.0.0.1/tcp/1234/",
+            "/ip4/127.0.0.1/udp/1234/quic",
+//            "/ip4/127.0.0.1/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
+//            "/ip4/127.0.0.1/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234",
+//            "/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
+//            "/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234",
+            "/unix/a/b/c/d/e",
+            "/unix/stdio",
+            "/ip4/1.2.3.4/tcp/80/unix/a/b/c/d/e/f"
+//            "/ip4/127.0.0.1/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234/unix/stdio",
+//            "/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234/unix/stdio"
         )
     }
 
     @ParameterizedTest
-    @MethodSource("params")
-    fun `Multihash digest and of`(desc: Multihash.Descriptor, length: Int, content: String, expected: String) {
-        val hex = BaseEncoding.base16()
-        val mh = Multihash.digest(desc, content.toByteArray().toByteBuf(), if (length == -1) null else length).bytes
-        val expected = hex.decode(expected.toUpperCase()).toByteBuf()
-        assertEquals(expected, mh)
-        with(Multihash.of(mh)) {
-            assertEquals(desc, this.desc)
-            if (length != -1) assertEquals(length, this.lengthBits)
-        }
+    @MethodSource("paramsInvalid")
+    fun invalidStringAddress(addr: String) {
+        Assertions.assertThrows(IllegalArgumentException::class.java, { Multiaddr(addr) })
     }
+
+    @ParameterizedTest
+    @MethodSource("paramsValid")
+    fun validStringAddress(addr: String) {
+        val multiaddr = Multiaddr(addr)
+        val bytes = multiaddr.getBytes()
+        val multiaddr1 = Multiaddr(bytes)
+        assertEquals(addr.toLowerCase().trimEnd('/'), multiaddr1.toString().toLowerCase())
+    }
+
 }

--- a/src/test/kotlin/io/libp2p/core/multiformats/MultiaddrTest.kt
+++ b/src/test/kotlin/io/libp2p/core/multiformats/MultiaddrTest.kt
@@ -1,8 +1,11 @@
 package io.libp2p.core.multiformats
 
+import io.libp2p.core.types.fromHex
+import io.libp2p.core.types.toHex
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 
 class MultiaddrTest {
@@ -90,6 +93,15 @@ class MultiaddrTest {
             "/ip4/127.0.0.1/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234/unix/stdio",
             "/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234/unix/stdio"
         )
+
+        @JvmStatic
+        fun toBytesParams() = listOf(
+            Arguments.of("/ip4/127.0.0.1/udp/1234", "047f000001910204d2".fromHex()),
+            Arguments.of("/ip4/127.0.0.1/tcp/4321", "047f0000010610e1".fromHex()),
+            Arguments.of("/ip4/127.0.0.1/udp/1234/ip4/127.0.0.1/tcp/4321", "047f000001910204d2047f0000010610e1".fromHex())
+            // TODO below fails due to Base32.decode() bug
+//            Arguments.of("/onion/aaimaq4ygg2iegci:80", "bc030010c0439831b48218480050".fromHex())
+        )
     }
 
     @ParameterizedTest
@@ -108,4 +120,10 @@ class MultiaddrTest {
             multiaddr1.toString().toLowerCase())
     }
 
+    @ParameterizedTest
+    @MethodSource("toBytesParams")
+    fun toBytes(str: String, bytes: ByteArray) {
+        assertEquals(bytes.toHex(), Multiaddr(str).getBytes().toHex())
+        assertEquals(str, Multiaddr(bytes).toString())
+    }
 }

--- a/src/test/kotlin/io/libp2p/core/multiformats/MultiaddrTest.kt
+++ b/src/test/kotlin/io/libp2p/core/multiformats/MultiaddrTest.kt
@@ -52,10 +52,10 @@ class MultiaddrTest {
             "/ip6/0:0:0:0:0:0:0:1",
             "/ip6/2601:9:4f81:9700:803e:ca65:66e8:c21",
             "/ip6/2601:9:4f81:9700:803e:ca65:66e8:c21/udp/1234/quic",
-//            "/ip6zone/x/ip6/fe80::1",
-//            "/ip6zone/x%y/ip6/fe80::1",
-//            "/ip6zone/x%y/ip6/::",
-//            "/ip6zone/x/ip6/fe80::1/udp/1234/quic",
+            "/ip6zone/x/ip6/fe80:0:0:0:0:0:0:1",
+            "/ip6zone/x%y/ip6/fe80:0:0:0:0:0:0:1",
+            "/ip6zone/x%y/ip6/0:0:0:0:0:0:0:0",
+            "/ip6zone/x/ip6/fe80:0:0:0:0:0:0:1/udp/1234/quic",
             "/onion/timaq4ygg2iegci7:1234",
             "/onion/timaq4ygg2iegci7:80/http",
             "/udp/0",
@@ -66,29 +66,29 @@ class MultiaddrTest {
             "/sctp/1234",
             "/udp/65535",
             "/tcp/65535",
-//            "/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
-//            "/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
+            "/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
+            "/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
             "/udp/1234/sctp/1234",
             "/udp/1234/udt",
             "/udp/1234/utp",
             "/tcp/1234/http",
             "/tcp/1234/https",
-//            "/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234",
-//            "/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234",
+            "/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234",
+            "/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234",
             "/ip4/127.0.0.1/udp/1234",
             "/ip4/127.0.0.1/udp/0",
             "/ip4/127.0.0.1/tcp/1234",
             "/ip4/127.0.0.1/tcp/1234/",
             "/ip4/127.0.0.1/udp/1234/quic",
-//            "/ip4/127.0.0.1/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
-//            "/ip4/127.0.0.1/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234",
-//            "/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
-//            "/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234",
+            "/ip4/127.0.0.1/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
+            "/ip4/127.0.0.1/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234",
+            "/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
+            "/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234",
             "/unix/a/b/c/d/e",
             "/unix/stdio",
-            "/ip4/1.2.3.4/tcp/80/unix/a/b/c/d/e/f"
-//            "/ip4/127.0.0.1/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234/unix/stdio",
-//            "/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234/unix/stdio"
+            "/ip4/1.2.3.4/tcp/80/unix/a/b/c/d/e/f",
+            "/ip4/127.0.0.1/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234/unix/stdio",
+            "/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234/unix/stdio"
         )
     }
 
@@ -104,7 +104,8 @@ class MultiaddrTest {
         val multiaddr = Multiaddr(addr)
         val bytes = multiaddr.getBytes()
         val multiaddr1 = Multiaddr(bytes)
-        assertEquals(addr.toLowerCase().trimEnd('/'), multiaddr1.toString().toLowerCase())
+        assertEquals(addr.toLowerCase().trimEnd('/').replace("/ipfs/", "/p2p/"),
+            multiaddr1.toString().toLowerCase())
     }
 
 }

--- a/src/test/kotlin/io/libp2p/core/multiformats/ProtocolTest.kt
+++ b/src/test/kotlin/io/libp2p/core/multiformats/ProtocolTest.kt
@@ -16,7 +16,8 @@ class ProtocolTest {
         assertEquals(Protocol.TCP, Protocol.get(6))
         assertEquals("12345", Protocol.TCP.bytesToAddress(Protocol.TCP.addressToBytes("12345")))
         for (protocol in Protocol.values()) {
-            assertEquals(protocol, Protocol.getOrThrow(protocol.encoded.toByteBuf().readUvarint().toInt()))
+            assertEquals(if (protocol == Protocol.IPFS) Protocol.P2P else protocol,
+                Protocol.getOrThrow(protocol.encoded.toByteBuf().readUvarint().toInt()))
         }
     }
 }

--- a/src/test/kotlin/io/libp2p/core/multiformats/ProtocolTest.kt
+++ b/src/test/kotlin/io/libp2p/core/multiformats/ProtocolTest.kt
@@ -1,5 +1,6 @@
 package io.libp2p.core.multiformats
 
+import io.libp2p.core.types.readUvarint
 import io.libp2p.core.types.toByteBuf
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -13,6 +14,9 @@ class ProtocolTest {
     fun test1() {
         assertEquals(Protocol.TCP, Protocol.get("tcp"))
         assertEquals(Protocol.TCP, Protocol.get(6))
-        assertEquals("12345", Protocol.TCP.bytesToAddress(Protocol.TCP.addressToBytes("12345").toByteBuf()))
+        assertEquals("12345", Protocol.TCP.bytesToAddress(Protocol.TCP.addressToBytes("12345")))
+        for (protocol in Protocol.values()) {
+            assertEquals(protocol, Protocol.getOrThrow(protocol.encoded.toByteBuf().readUvarint().toInt()))
+        }
     }
 }

--- a/src/test/kotlin/io/libp2p/core/multiformats/ProtocolTest.kt
+++ b/src/test/kotlin/io/libp2p/core/multiformats/ProtocolTest.kt
@@ -1,0 +1,18 @@
+package io.libp2p.core.multiformats
+
+import io.libp2p.core.types.toByteBuf
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Created by Anton Nashatyrev on 11.06.2019.
+ */
+class ProtocolTest {
+
+    @Test
+    fun test1() {
+        assertEquals(Protocol.TCP, Protocol.get("tcp"))
+        assertEquals(Protocol.TCP, Protocol.get(6))
+        assertEquals("12345", Protocol.TCP.bytesToAddress(Protocol.TCP.addressToBytes("12345").toByteBuf()))
+    }
+}

--- a/src/test/kotlin/io/libp2p/core/types/UvariantTest.kt
+++ b/src/test/kotlin/io/libp2p/core/types/UvariantTest.kt
@@ -1,0 +1,22 @@
+package io.libp2p.core.types
+
+import io.netty.buffer.Unpooled
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+/**
+ * Created by Anton Nashatyrev on 11.06.2019.
+ */
+class UvariantTest {
+
+    @Test
+    fun test1() {
+        for (i in 0 .. 10000L) {
+            val buf = Unpooled.buffer()
+            buf.writeUvarint(i);
+            Assertions.assertEquals(i, buf.readUvarint())
+            Assertions.assertFalse(buf.isReadable)
+        }
+    }
+
+}


### PR DESCRIPTION
There is still a dependency https://github.com/multiformats/java-multiaddr to address P2P protocol. 
Also there is a bug with `Base32.encode()` there which affects `ONION` protocol
Should we address those issues now or just create a couple of issues and leave it as is for now? 
